### PR TITLE
domonda-react-form: Expose `registerLocale` func from the date picker

### DIFF
--- a/packages/domonda-react-form/src/FormDateField/FormDateField.tsx
+++ b/packages/domonda-react-form/src/FormDateField/FormDateField.tsx
@@ -7,6 +7,8 @@
 import React from 'react';
 import { useFormDateField, UseFormDateFieldProps, FormDateFieldAPI } from './useFormDateField';
 
+export { registerLocale } from 'react-datepicker';
+
 export interface FormDateFieldProps extends UseFormDateFieldProps {
   children: (api: FormDateFieldAPI) => React.ReactElement | null;
 }


### PR DESCRIPTION
Closes: #44 